### PR TITLE
Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/pipeline-builder-canary`
 
-The Paketo Pipeline Builder Canary Buildpack is a Cloud Native Buildpack that does nothing. It's primary purpose is to function as a validation for changes being made to the pipeline-builder.
+The Paketo Buildpack for Pipeline Builder Canary is a Cloud Native Buildpack that does nothing. It's primary purpose is to function as a validation for changes being made to the pipeline-builder.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/pipeline-builder-canary"
   id = "paketo-buildpacks/pipeline-builder-canary"
   keywords = ["nothing"]
-  name = "Paketo Pipeline Builder Canary Buildpack"
+  name = "Paketo Buildpack for Pipeline Builder Canary"
   version = "{{.version}}"
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Pipeline Builder Canary Buildpack' to 'Paketo Buildpack for Pipeline Builder Canary'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
