### PR TITLE
Update `pipeline-descriptor.yml`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @paketo-buildpacks/java-buildpacks
+* @paketo-buildpacks/java-maintainers

--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -1,20 +1,20 @@
 github:
   username: ${{ secrets.JAVA_GITHUB_USERNAME }}
-  token:    ${{ secrets.JAVA_GITHUB_TOKEN }}
+  token:    ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
 codeowners:
 - path:  "*"
-  owner: "@paketo-buildpacks/java-buildpacks"
+  owner: "@paketo-buildpacks/java-maintainers"
 
 package:
-  repositories:   ["index.docker.io/paketobuildpacks/pipeline-builder-canary","gcr.io/paketo-buildpacks/pipeline-builder-canary"]
+  repositories:   ["docker.io/paketobuildpacks/pipeline-builder-canary","gcr.io/paketo-buildpacks/pipeline-builder-canary"]
   register:       true
-  registry_token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+  registry_token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
 docker_credentials:
   - registry: gcr.io
     username: _json_key
-    password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}
+    password: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
   - registry: docker.io
     username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
     password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}

--- a/.github/workflows/pb-create-package.yml
+++ b/.github/workflows/pb-create-package.yml
@@ -13,7 +13,7 @@ jobs:
               if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
               uses: docker/login-action@v2
               with:
-                password: ${{ secrets.JAVA_GCLOUD_SERVICE_ACCOUNT_KEY }}
+                password: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
                 registry: gcr.io
                 username: _json_key
             - name: Docker login docker.io
@@ -195,7 +195,7 @@ jobs:
                     --format "${FORMAT}"
                 fi
               env:
-                PACKAGES: index.docker.io/paketobuildpacks/pipeline-builder-canary gcr.io/paketo-buildpacks/pipeline-builder-canary
+                PACKAGES: docker.io/paketobuildpacks/pipeline-builder-canary gcr.io/paketo-buildpacks/pipeline-builder-canary
                 PUBLISH: "true"
                 VERSION: ${{ steps.version.outputs.version }}
                 VERSION_MAJOR: ${{ steps.version.outputs.version-major }}
@@ -221,11 +221,11 @@ jobs:
                   --field "body=${RELEASE_BODY//<!-- DIGEST PLACEHOLDER -->/\`${DIGEST}\`}"
               env:
                 DIGEST: ${{ steps.package.outputs.digest }}
-                GITHUB_TOKEN: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
             - if: ${{ true }}
               uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.1
               with:
-                address: index.docker.io/paketobuildpacks/pipeline-builder-canary@${{ steps.package.outputs.digest }}
+                address: docker.io/paketobuildpacks/pipeline-builder-canary@${{ steps.package.outputs.digest }}
                 id: paketo-buildpacks/pipeline-builder-canary
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
                 version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/pb-minimal-labels.yml
+++ b/.github/workflows/pb-minimal-labels.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: mheap/github-action-required-labels@v2
+            - uses: mheap/github-action-required-labels@v3
               with:
                 count: 1
                 labels: semver:major, semver:minor, semver:patch
@@ -22,7 +22,7 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: mheap/github-action-required-labels@v2
+            - uses: mheap/github-action-required-labels@v3
               with:
                 count: 1
                 labels: type:bug, type:dependency-upgrade, type:documentation, type:enhancement, type:question, type:task

--- a/.github/workflows/pb-synchronize-labels.yml
+++ b/.github/workflows/pb-synchronize-labels.yml
@@ -14,4 +14,4 @@ jobs:
             - uses: actions/checkout@v3
             - uses: micnncim/action-label-syncer@v1
               env:
-                GITHUB_TOKEN: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-draft-release.yml
+++ b/.github/workflows/pb-update-draft-release.yml
@@ -12,12 +12,12 @@ jobs:
             - id: release-drafter
               uses: release-drafter/release-drafter@v5
               env:
-                GITHUB_TOKEN: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
             - uses: actions/checkout@v3
             - name: Update draft release with buildpack information
               uses: docker://ghcr.io/paketo-buildpacks/actions/draft-release:main
               with:
-                github_token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                github_token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
                 release_body: ${{ steps.release-drafter.outputs.body }}
                 release_id: ${{ steps.release-drafter.outputs.id }}
                 release_name: ${{ steps.release-drafter.outputs.name }}

--- a/.github/workflows/pb-update-go.yml
+++ b/.github/workflows/pb-update-go.yml
@@ -69,4 +69,4 @@ jobs:
                 labels: ${{ steps.update-go.outputs.commit-semver }}, type:task
                 signoff: true
                 title: ${{ steps.update-go.outputs.commit-title }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-maven.yml
+++ b/.github/workflows/pb-update-maven.yml
@@ -111,4 +111,4 @@ jobs:
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
                 title: Bump maven from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-pipeline.yml
+++ b/.github/workflows/pb-update-pipeline.yml
@@ -64,7 +64,7 @@ jobs:
                 printf "release-notes<<%s\n%s\n%s\n" "${DELIMITER}" "${RELEASE_NOTES}" "${DELIMITER}" >> "${GITHUB_OUTPUT}" # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
               env:
                 DESCRIPTOR: .github/pipeline-descriptor.yml
-                GITHUB_TOKEN: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
             - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
@@ -84,4 +84,4 @@ jobs:
                 labels: semver:patch, type:task
                 signoff: true
                 title: Bump pipeline from ${{ steps.pipeline.outputs.old-version }} to ${{ steps.pipeline.outputs.new-version }}
-                token: ${{ secrets.JAVA_GITHUB_TOKEN }}
+                token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Update `pipeline-descriptor.yml` to use new tokens, codeowners, and to publish to DockerHub as well as GCR.io
