### PR TITLE
Remove manual gomod updates and use dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,19 @@
 version: 2
 updates:
-    - package-ecosystem: gomod
-      directory: /
-      schedule:
-        interval: daily
-      ignore:
-        - dependency-name: github.com/onsi/gomega
-      labels:
-        - semver:patch
-        - type:dependency-upgrade
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - semver:patch
+      - type:dependency-upgrade
+    allow:
+      - dependency-type: "all"
+    groups:
+      gomod:
+        patterns:
+          - "*"
+        # group all minor and patch dependency updates together
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/pb-update-go.yml
+++ b/.github/workflows/pb-update-go.yml
@@ -29,8 +29,6 @@ jobs:
 
                 go mod edit -go="$GO_VERSION"
                 go mod tidy
-                go get -u -t ./...
-                go mod tidy
 
                 git add go.mod go.sum
                 git checkout -- .


### PR DESCRIPTION
## Summary

This configures dependabot to update all go modules and to batch them together, so we get similar behavior to what we were doing manually but better commit messages. This removes the manual update of gomods but it does not remove the capability to bump go versions using the pipeline.

## Use Cases

Improve commit messages and still have gomods updated automatically.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
