### PR TITLE
Run octo with Go 21

### DIFF
--- a/.github/workflows/pb-create-package.yml
+++ b/.github/workflows/pb-create-package.yml
@@ -25,7 +25,7 @@ jobs:
                 username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
             - uses: actions/setup-go@v5
               with:
-                go-version: "1.20"
+                go-version: "1.21"
             - name: Install create-package
               run: |
                 #!/usr/bin/env bash
@@ -33,9 +33,9 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/create-package@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.5.3
+            - uses: buildpacks/github-actions/setup-tools@v5.6.0
               with:
-                crane-version: 0.19.0
+                crane-version: 0.19.1
                 yj-version: 5.1.0
             - name: Install pack
               run: |
@@ -106,7 +106,7 @@ jobs:
               run: |
                 #!/usr/bin/env bash
 
-                set -xeuo pipefail
+                set -euo pipefail
 
                 # With Go 1.20, we need to set this so that we produce statically compiled binaries
                 #
@@ -144,7 +144,7 @@ jobs:
               run: |-
                 #!/usr/bin/env bash
 
-                set -xeuo pipefail
+                set -euo pipefail
 
                 COMPILED_BUILDPACK="${HOME}/buildpack"
 
@@ -188,7 +188,7 @@ jobs:
                 else
                   pack -v buildpack package \
                     "${PACKAGE}:${VERSION}" ${CONFIG} \
-                    --format "${FORMAT}"
+                    --format "${FORMAT}" $([ -n "$TTL_SH_PUBLISH" ] && [ "$TTL_SH_PUBLISH" = "true" ] && echo "--publish")
                 fi
               env:
                 PACKAGES: docker.io/paketobuildpacks/pipeline-builder-canary gcr.io/paketo-buildpacks/pipeline-builder-canary
@@ -219,7 +219,7 @@ jobs:
                 DIGEST: ${{ steps.package.outputs.digest }}
                 GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
             - if: ${{ true }}
-              uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:5.5.3
+              uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:5.6.0
               with:
                 address: docker.io/paketobuildpacks/pipeline-builder-canary@${{ steps.package.outputs.digest }}
                 id: paketo-buildpacks/pipeline-builder-canary

--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -17,7 +17,7 @@ jobs:
         steps:
             - uses: actions/setup-go@v5
               with:
-                go-version: "1.20"
+                go-version: "1.21"
             - name: Install create-package
               run: |
                 #!/usr/bin/env bash
@@ -93,7 +93,7 @@ jobs:
               run: |
                 #!/usr/bin/env bash
 
-                set -xeuo pipefail
+                set -euo pipefail
 
                 # With Go 1.20, we need to set this so that we produce statically compiled binaries
                 #
@@ -129,7 +129,7 @@ jobs:
               run: |-
                 #!/usr/bin/env bash
 
-                set -xeuo pipefail
+                set -euo pipefail
 
                 COMPILED_BUILDPACK="${HOME}/buildpack"
 
@@ -173,11 +173,12 @@ jobs:
                 else
                   pack -v buildpack package \
                     "${PACKAGE}:${VERSION}" ${CONFIG} \
-                    --format "${FORMAT}"
+                    --format "${FORMAT}" $([ -n "$TTL_SH_PUBLISH" ] && [ "$TTL_SH_PUBLISH" = "true" ] && echo "--publish")
                 fi
               env:
                 FORMAT: image
                 PACKAGES: test
+                TTL_SH_PUBLISH: "false"
                 VERSION: ${{ steps.version.outputs.version }}
     unit:
         name: Unit Test
@@ -192,7 +193,7 @@ jobs:
                 restore-keys: ${{ runner.os }}-go-
             - uses: actions/setup-go@v5
               with:
-                go-version: "1.20"
+                go-version: "1.21"
             - name: Install richgo
               run: |
                 #!/usr/bin/env bash

--- a/.github/workflows/pb-update-go.yml
+++ b/.github/workflows/pb-update-go.yml
@@ -11,7 +11,7 @@ jobs:
         steps:
             - uses: actions/setup-go@v5
               with:
-                go-version: "1.20"
+                go-version: "1.21"
             - uses: actions/checkout@v4
             - name: Update Go Version & Modules
               id: update-go
@@ -47,7 +47,7 @@ jobs:
                 echo "commit-body=${COMMIT_BODY}" >> "$GITHUB_OUTPUT"
                 echo "commit-semver=${COMMIT_SEMVER}" >> "$GITHUB_OUTPUT"
               env:
-                GO_VERSION: "1.20"
+                GO_VERSION: "1.21"
             - uses: peter-evans/create-pull-request@v6
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>

--- a/.github/workflows/pb-update-maven.yml
+++ b/.github/workflows/pb-update-maven.yml
@@ -11,7 +11,7 @@ jobs:
         steps:
             - uses: actions/setup-go@v5
               with:
-                go-version: "1.20"
+                go-version: "1.21"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,9 +19,9 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.5.3
+            - uses: buildpacks/github-actions/setup-tools@v5.6.0
               with:
-                crane-version: 0.19.0
+                crane-version: 0.19.1
                 yj-version: 5.1.0
             - uses: actions/checkout@v4
             - id: dependency

--- a/.github/workflows/pb-update-pipeline.yml
+++ b/.github/workflows/pb-update-pipeline.yml
@@ -16,7 +16,7 @@ jobs:
         steps:
             - uses: actions/setup-go@v5
               with:
-                go-version: "1.20"
+                go-version: "1.21"
             - name: Install octo
               run: |
                 #!/usr/bin/env bash

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 GOMOD=$(head -1 go.mod | awk '{print $2}')
-GOOS="linux" go build -ldflags='-s -w' -o linux/amd64/bin/main "$GOMOD/cmd/main"
+GOOS="linux" GOARCH="amd64" go build -ldflags='-s -w' -o linux/amd64/bin/main "$GOMOD/cmd/main"
 GOOS="linux" GOARCH="arm64" go build -ldflags='-s -w' -o linux/arm64/bin/main "$GOMOD/cmd/main"
 
 if [ "${STRIP:-false}" != "false" ]; then


### PR DESCRIPTION
## Summary

Testing Go 1.21 update.

## Use Cases

Go 1.20 is EOL.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
