### PR TITLE
Test flattening composite images

### DIFF
--- a/.github/workflows/pb-create-package.yml
+++ b/.github/workflows/pb-create-package.yml
@@ -135,7 +135,7 @@ jobs:
                 cd "${COMPILED_BUILDPACK}"
                 CONFIG=""
                 if [ -f "${COMPILED_BUILDPACK}/package.toml" ]; then
-                  CONFIG="--config ${COMPILED_BUILDPACK}/package.toml"
+                  CONFIG="--config ${COMPILED_BUILDPACK}/package.toml --flatten"
                 fi
 
                 PACKAGE_LIST=($PACKAGES)

--- a/.github/workflows/pb-create-package.yml
+++ b/.github/workflows/pb-create-package.yml
@@ -34,16 +34,13 @@ jobs:
               with:
                 pack-version: 0.36.4
             - name: Enable pack Experimental
-              if: ${{ false }}
               run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
                 echo "Enabling pack experimental features"
-
-                mkdir -p "${HOME}"/.pack
-                echo "experimental = true" >> "${HOME}"/.pack/config.toml
+                pack config experimental true
             - uses: actions/checkout@v4
             - if: ${{ false }}
               uses: actions/cache@v4

--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -127,7 +127,7 @@ jobs:
                 cd "${COMPILED_BUILDPACK}"
                 CONFIG=""
                 if [ -f "${COMPILED_BUILDPACK}/package.toml" ]; then
-                  CONFIG="--config ${COMPILED_BUILDPACK}/package.toml"
+                  CONFIG="--config ${COMPILED_BUILDPACK}/package.toml --flatten"
                 fi
 
                 PACKAGE_LIST=($PACKAGES)

--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -29,16 +29,13 @@ jobs:
               with:
                 pack-version: 0.36.4
             - name: Enable pack Experimental
-              if: ${{ false }}
               run: |
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
                 echo "Enabling pack experimental features"
-
-                mkdir -p "${HOME}"/.pack
-                echo "experimental = true" >> "${HOME}"/.pack/config.toml
+                pack config experimental true
             - uses: actions/checkout@v4
             - uses: actions/cache@v4
               with:


### PR DESCRIPTION
Test flattening composite images. This is a small change, but I think it should be sufficient to flatten the generated image.

The CONFIG is only set for composite images, so it should not impact component buildpacks.