### PR TITLE
Update create-pull-request action to version 8

### DIFF
--- a/.github/workflows/pb-update-pipeline.yml
+++ b/.github/workflows/pb-update-pipeline.yml
@@ -71,7 +71,7 @@ jobs:
               env:
                 DESCRIPTOR: .github/pipeline-descriptor.yml
                 GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v8
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: |-


### PR DESCRIPTION
There is an issue with v6 and the updated checkout action version, see https://github.com/peter-evans/create-pull-request/issues/4272. This only happens here because I updated the pipeline test to 1.46.0 which updated checkout but not peter-evans/create-pull-request action. This manually unblocks the update-pipline actions, so we can then run the pipeline-update action.